### PR TITLE
fix: prevent unwrap panic from dioxus-core

### DIFF
--- a/src/components/atoms/messages/message.rs
+++ b/src/components/atoms/messages/message.rs
@@ -28,7 +28,7 @@ pub struct ThreadPreview {
 #[derive(PartialEq, Props, Debug, Clone)]
 pub struct Message {
     pub id: i64,
-    pub event_id: Option<String>,
+    pub event_id: String,
     pub content: TimelineMessageType,
     pub display_name: String,
     pub avatar_uri: Option<String>,

--- a/src/components/molecules/input_message.rs
+++ b/src/components/molecules/input_message.rs
@@ -147,7 +147,7 @@ pub fn InputMessage<'a>(cx: Scope<'a, InputMessageProps<'a>>) -> Element<'a> {
                     message: Message {
                         id: 1,
                         display_name: replying.display_name.clone(),
-                        event_id: None,
+                        event_id: String::from(""),
                         avatar_uri: replying.avatar_uri.clone(),
                         content: replying.content.clone(),
                         reply: None,

--- a/src/components/molecules/list.rs
+++ b/src/components/molecules/list.rs
@@ -102,10 +102,9 @@ pub fn List<'a>(cx: Scope<'a, ListProps<'a>>) -> Element<'a> {
                                 TimelineRelation::None(message) => {
                                     let message = message.clone();
                                     let event_id = message.event_id.clone();
-
                                     cx.render(rsx!(
                                         MessageView {
-                                            key: "{i}",
+                                            key: "{event_id}",
                                             message: Message {
                                                 id: i as i64,
                                                 event_id: message.event_id,
@@ -124,17 +123,15 @@ pub fn List<'a>(cx: Scope<'a, ListProps<'a>>) -> Element<'a> {
                                                         info!("TODO: handle download")
                                                     }
                                                     MenuOption::Reply => {
-                                                        if let Some(eid) = &event_id {
-                                                            let replying = ReplyingTo { 
-                                                                event_id: eid.clone(), 
-                                                                content: message.body.clone(), 
-                                                                display_name: message.sender.name.clone(), 
-                                                                avatar_uri: message.sender.avatar_uri.clone(),
-                                                                origin: message.origin.clone()
-                                                            };
-                                                            
-                                                            replying_to.set(Some(replying));
-                                                        }
+                                                        let replying = ReplyingTo { 
+                                                            event_id: event_id.clone(), 
+                                                            content: message.body.clone(), 
+                                                            display_name: message.sender.name.clone(), 
+                                                            avatar_uri: message.sender.avatar_uri.clone(),
+                                                            origin: message.origin.clone()
+                                                        };
+                                                        
+                                                        replying_to.set(Some(replying));
                                                     }
                                                     MenuOption::Close => {
                                                         info!("close");
@@ -145,9 +142,7 @@ pub fn List<'a>(cx: Scope<'a, ListProps<'a>>) -> Element<'a> {
                                                     MenuOption::CreateThread => {
                                                         info!("create thread");
                                                         let thread = vec![TimelineMessage { event_id: event_id.clone(), sender: message.sender.clone(), body: message.body.clone(), origin: message.origin.clone(), time: message.time.clone() }];
-                                                        if let Some(e) = &event_id {
-                                                            threading_to.set(Some(TimelineThread { event_id: e.clone(), thread, count: 0, latest_event: e.clone() }));
-                                                        }
+                                                        threading_to.set(Some(TimelineThread { event_id: event_id.clone(), thread, count: 0, latest_event: event_id.clone() }));
                                                     }
 
                                                 }
@@ -176,7 +171,7 @@ pub fn List<'a>(cx: Scope<'a, ListProps<'a>>) -> Element<'a> {
 
                                     cx.render(rsx!(
                                         MessageView {
-                                            key: "{i}",
+                                            key: "{event_id}",
                                             message: Message {
                                                 id: i as i64,
                                                 event_id: message.event_id,
@@ -197,17 +192,15 @@ pub fn List<'a>(cx: Scope<'a, ListProps<'a>>) -> Element<'a> {
                                                         info!("TODO: handle download")
                                                     }
                                                     MenuOption::Reply => {
-                                                        if let Some(eid) = &event_id {
-                                                            let replying = ReplyingTo { 
-                                                                event_id: eid.clone(), 
-                                                                content: message.body.clone(), 
-                                                                display_name: message.sender.name.clone(), 
-                                                                avatar_uri: message.sender.avatar_uri.clone(),
-                                                                origin: message.origin.clone()
-                                                            };
-                                                            
-                                                            replying_to.set(Some(replying));
-                                                        }
+                                                        let replying = ReplyingTo { 
+                                                            event_id: event_id.clone(), 
+                                                            content: message.body.clone(), 
+                                                            display_name: message.sender.name.clone(), 
+                                                            avatar_uri: message.sender.avatar_uri.clone(),
+                                                            origin: message.origin.clone()
+                                                        };
+                                                        
+                                                        replying_to.set(Some(replying));
                                                     }
                                                     MenuOption::Close => {
                                                         info!("close");
@@ -252,10 +245,9 @@ pub fn List<'a>(cx: Scope<'a, ListProps<'a>>) -> Element<'a> {
                                         thread_avatars.push(Sender{avatar_uri: t.sender.avatar_uri.clone(), display_name: t.sender.name.clone()})
                                     }
 
-
                                     cx.render(rsx!(
                                         MessageView {
-                                            key: "{i}",
+                                            key: "{event_id}",
                                             message: Message {
                                                 id: i as i64,
                                                 event_id: head_message.event_id.clone(),
@@ -311,10 +303,9 @@ pub fn List<'a>(cx: Scope<'a, ListProps<'a>>) -> Element<'a> {
                                 messages.iter().enumerate().map(|(i, m)| {
                                     let message = m.clone();
                                     let event_id = message.event_id.clone();
-
                                     cx.render(rsx!(
                                         MessageView {
-                                            key: "{i}",
+                                            key: "{event_id}",
                                             message: Message {
                                                 id: i as i64,
                                                 event_id: message.event_id,
@@ -335,17 +326,15 @@ pub fn List<'a>(cx: Scope<'a, ListProps<'a>>) -> Element<'a> {
                                                         info!("TODO: handle download")
                                                     }
                                                     MenuOption::Reply => {
-                                                        if let Some(eid) = &event_id {
-                                                            let replying = ReplyingTo { 
-                                                                event_id: eid.clone(), 
-                                                                content: message.body.clone(), 
-                                                                display_name: message.sender.name.clone(), 
-                                                                avatar_uri: message.sender.avatar_uri.clone(),
-                                                                origin: message.origin.clone()
-                                                            };
-                                                            
-                                                            replying_to.set(Some(replying));
-                                                        }
+                                                        let replying = ReplyingTo { 
+                                                            event_id: event_id.clone(), 
+                                                            content: message.body.clone(), 
+                                                            display_name: message.sender.name.clone(), 
+                                                            avatar_uri: message.sender.avatar_uri.clone(),
+                                                            origin: message.origin.clone()
+                                                        };
+                                                        
+                                                        replying_to.set(Some(replying));
                                                     }
                                                     MenuOption::Close => {
                                                         info!("close");

--- a/src/hooks/factory/message_factory.rs
+++ b/src/hooks/factory/message_factory.rs
@@ -54,7 +54,7 @@ impl MessageFactory for TextMessageFactory {
     ) -> TimelineRelation {
         TimelineRelation::None(TimelineMessage {
             body: content.clone(),
-            event_id: Some(uuid.to_string()),
+            event_id: uuid.to_string(),
             sender: RoomMember {
                 id: session.user_id.clone(),
                 name: String::from("x"),
@@ -81,7 +81,7 @@ impl MessageFactory for ReplyMessageFactory {
         TimelineRelation::Reply(TimelineMessageReply {
             event: TimelineMessage {
                 body: content.clone(),
-                event_id: Some(uuid.to_string()),
+                event_id: uuid.to_string(),
                 sender: RoomMember {
                     id: session.user_id.clone(),
                     name: String::from("x"),
@@ -91,7 +91,7 @@ impl MessageFactory for ReplyMessageFactory {
                 time: time.to_string(),
             },
             reply: Some(TimelineMessage {
-                event_id: Some(self.relation.event_id.clone()),
+                event_id: self.relation.event_id.clone(),
                 sender: RoomMember {
                     id: String::from(""),
                     name: self.relation.display_name.clone(),
@@ -121,7 +121,7 @@ impl MessageFactory for CustomThreadMessageFactory {
 
         t.thread.push(TimelineMessage {
             body: content.clone(),
-            event_id: Some(uuid.to_string()),
+            event_id: uuid.to_string(),
             sender: RoomMember {
                 id: session.user_id.clone(),
                 name: String::from("x"),

--- a/src/hooks/use_listen_message.rs
+++ b/src/hooks/use_listen_message.rs
@@ -92,19 +92,10 @@ pub fn use_listen_message(cx: &ScopeState) -> &UseListenMessagesState {
                                             TimelineRelation::CustomThread(TimelineThread {
                                                 event_id: timeline_thread.event_id.clone(),
                                                 thread: timeline_thread.thread.clone(),
-                                                latest_event: match timeline_thread.thread
+                                                latest_event: timeline_thread.thread
                                                     [timeline_thread.thread.len() - 1]
                                                     .clone()
-                                                    .event_id
-                                                {
-                                                    Some(id) => id,
-                                                    None => {
-                                                        notification.handle_error(
-                                                            &key_common_error_thread_id,
-                                                        );
-                                                        return;
-                                                    }
-                                                },
+                                                    .event_id,
                                                 count: timeline_thread.thread.len(),
                                             });
 
@@ -123,12 +114,7 @@ pub fn use_listen_message(cx: &ScopeState) -> &UseListenMessagesState {
                                         return false;
                                     };
 
-                                    let Some(ref id) = timeline_message.event_id else {
-                                        notification.handle_error(&key_common_error_event_id);
-                                        return false;
-                                    };
-
-                                    t.event_id.eq(id)
+                                    t.event_id.eq(&timeline_message.event_id)
                                 });
 
                                 match position {
@@ -200,20 +186,18 @@ pub fn use_listen_message(cx: &ScopeState) -> &UseListenMessagesState {
                                         }));
                                     }
                                 } else if let TimelineRelation::None(t) = m {
-                                    if let Some(event_id) = &t.event_id {
-                                        if event_id.eq(&thread.event_id) {
-                                            let mut new_thread = thread.clone();
+                                    if t.event_id.eq(&thread.event_id) {
+                                        let mut new_thread = thread.clone();
 
-                                            new_thread.thread.push(t.clone());
+                                        new_thread.thread.push(t.clone());
 
-                                            threading_to.set(Some(TimelineThread {
-                                                event_id: event_id.clone(),
-                                                thread: new_thread.thread.clone(),
-                                                count: new_thread.count.clone(),
-                                                latest_event: new_thread.latest_event.clone(),
-                                            }));
-                                        }
-                                    };
+                                        threading_to.set(Some(TimelineThread {
+                                            event_id: t.event_id.clone(),
+                                            thread: new_thread.thread.clone(),
+                                            count: new_thread.count.clone(),
+                                            latest_event: new_thread.latest_event.clone(),
+                                        }));
+                                    }
                                 }
                             });
                         }
@@ -324,20 +308,16 @@ pub fn use_listen_message(cx: &ScopeState) -> &UseListenMessagesState {
 
                             if let Some((uuid, event_id)) = to_find {
                                 position = back_messages.iter().position(|m| match m {
-                                    TimelineRelation::None(relation) => {
-                                        relation.event_id.as_ref() == Some(&uuid)
-                                    }
+                                    TimelineRelation::None(relation) => relation.event_id == uuid,
                                     TimelineRelation::Reply(relation) => {
-                                        relation.event.event_id.as_ref() == Some(&uuid)
+                                        relation.event.event_id == uuid
                                     }
-                                    TimelineRelation::CustomThread(relation) => relation
-                                        .thread
-                                        .iter()
-                                        .any(|rm| rm.event_id.as_ref() == Some(&uuid)),
-                                    TimelineRelation::Thread(relation) => relation
-                                        .thread
-                                        .iter()
-                                        .any(|rm| rm.event_id.as_ref() == Some(&uuid)),
+                                    TimelineRelation::CustomThread(relation) => {
+                                        relation.thread.iter().any(|rm| rm.event_id == uuid)
+                                    }
+                                    TimelineRelation::Thread(relation) => {
+                                        relation.thread.iter().any(|rm| rm.event_id == uuid)
+                                    }
                                 });
 
                                 info!("position {:?}", position);

--- a/src/services/matrix.rs
+++ b/src/services/matrix.rs
@@ -452,7 +452,7 @@ pub mod matrix {
 
     #[derive(PartialEq, Debug, Clone)]
     pub struct TimelineMessage {
-        pub event_id: Option<String>,
+        pub event_id: String,
         pub sender: RoomMember,
         pub body: TimelineMessageType,
         pub origin: EventOrigin,
@@ -567,8 +567,7 @@ pub mod matrix {
                                 thread: thread.thread.clone(),
                                 latest_event: thread.thread[thread.thread.len() - 1]
                                     .clone()
-                                    .event_id
-                                    .expect("can't get eventid from thread: timeline"),
+                                    .event_id,
                                 count: thread.thread.len(),
                             });
 
@@ -583,10 +582,7 @@ pub mod matrix {
                                 return false;
                             };
 
-                            thread.event_id.eq(message
-                                .event_id
-                                .as_ref()
-                                .expect("can't compare event id: timeline"))
+                            thread.event_id.eq(&message.event_id)
                         });
 
                         let Some(p) = position else {
@@ -785,7 +781,7 @@ pub mod matrix {
 
                     if let Some(uri) = https_uri {
                         message_result = Some(TimelineMessage {
-                            event_id: Some(String::from(event.as_str())),
+                            event_id: event.to_string(),
                             sender: member.clone(),
                             body: TimelineMessageType::Image(FileContent {
                                 size,
@@ -829,7 +825,7 @@ pub mod matrix {
 
                     if let Ok(content) = media_content {
                         message_result = Some(TimelineMessage {
-                            event_id: Some(String::from(event.as_str())),
+                            event_id: event.to_string(),
                             sender: member.clone(),
                             body: TimelineMessageType::Image(FileContent {
                                 size,
@@ -848,7 +844,7 @@ pub mod matrix {
             },
             MessageType::Text(content) => {
                 message_result = Some(TimelineMessage {
-                    event_id: Some(String::from(event.as_str())),
+                    event_id: event.to_string(),
                     sender: member.clone(),
                     body: TimelineMessageType::Text(content.body.clone()),
                     origin: if member.id.eq(logged_user_id) {
@@ -886,7 +882,7 @@ pub mod matrix {
                         .flatten();
 
                     message_result = Some(TimelineMessage {
-                        event_id: Some(String::from(event.as_str())),
+                        event_id: event.to_string(),
                         sender: member.clone(),
                         body: TimelineMessageType::File(FileContent {
                             size,
@@ -916,7 +912,7 @@ pub mod matrix {
                         .flatten();
 
                     message_result = Some(TimelineMessage {
-                        event_id: Some(String::from(event.as_str())),
+                        event_id: event.to_string(),
                         sender: member.clone(),
                         body: TimelineMessageType::File(FileContent {
                             size,
@@ -948,7 +944,7 @@ pub mod matrix {
                         .flatten();
 
                     message_result = Some(TimelineMessage {
-                        event_id: Some(String::from(event.as_str())),
+                        event_id: event.to_string(),
                         sender: member.clone(),
                         body: TimelineMessageType::Video(FileContent {
                             size,
@@ -987,7 +983,7 @@ pub mod matrix {
 
                     if let Ok(content) = message_content {
                         message_result = Some(TimelineMessage {
-                            event_id: Some(String::from(event.as_str())),
+                            event_id: event.to_string(),
                             sender: member.clone(),
                             body: TimelineMessageType::Video(FileContent {
                                 size,
@@ -1057,9 +1053,9 @@ pub mod matrix {
                                 let n = uncleared_content.replace(&to_remove, "").clone();
 
                                 let content_body = TimelineMessageType::Text(n);
-
+                                let event = event.event.deserialize().ok()?.event_id().to_string();
                                 final_message.event = TimelineMessage {
-                                    event_id: None,
+                                    event_id: event,
                                     sender: member.clone(),
                                     body: content_body,
                                     origin: if member.id.eq(logged_user_id) {
@@ -1080,9 +1076,9 @@ pub mod matrix {
                                 let n = uncleared_content.replace(&to_remove, "").clone();
 
                                 let content_body = TimelineMessageType::Text(n);
-
+                                let event = event.event.deserialize().ok()?.event_id().to_string();
                                 final_message.event = TimelineMessage {
-                                    event_id: None,
+                                    event_id: event,
                                     sender: member.clone(),
                                     body: content_body,
                                     origin: if member.id.eq(logged_user_id) {


### PR DESCRIPTION
Change the key of the element to the `event_id` to prevent "**empty**" nodes